### PR TITLE
fix: smooth scroll to tools on support page

### DIFF
--- a/src/components/support/SupportCategoryGrid.tsx
+++ b/src/components/support/SupportCategoryGrid.tsx
@@ -78,7 +78,7 @@ const supportCategories = [
 
 export function SupportCategoryGrid() {
   return (
-    <section className="py-16">
+    <section id="support-tools" className="py-16">
       <FadeContainer className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <FadeDiv>
           <div className="text-center">

--- a/src/components/support/SupportHero.tsx
+++ b/src/components/support/SupportHero.tsx
@@ -105,10 +105,17 @@ export function SupportHero() {
                   <p className="mt-2 text-sm leading-6 text-gray-600">
                     Track orders, check compatibility, manage billing
                   </p>
-                  <Button asChild variant="outline" className="mt-3">
-                    <Link href={siteConfig.baseLinks.support}>
-                      Browse Tools
-                    </Link>
+                  <Button
+                    variant="outline"
+                    className="mt-3"
+                    type="button"
+                    onClick={() =>
+                      document
+                        .getElementById("support-tools")
+                        ?.scrollIntoView({ behavior: "smooth" })
+                    }
+                  >
+                    Browse Tools
                   </Button>
                   <p className="text-xs text-gray-500 mt-2">
                     Available 24/7


### PR DESCRIPTION
## Summary
- smooth-scroll to tools when clicking Browse Tools on support page
- add anchor id for tools section

## Testing
- `pnpm run lint`
- `pnpm run build` *(fails: Failed to collect page data for /api/order-details)*

------
https://chatgpt.com/codex/tasks/task_e_68b937bb2358832aab7643360414fe52