### PR TITLE
feat: link shop tint kits to products page

### DIFF
--- a/src/components/ui/Hero.tsx
+++ b/src/components/ui/Hero.tsx
@@ -1,4 +1,5 @@
 import { RiArrowRightUpLine } from "@remixicon/react"
+import Link from "next/link"
 import { FadeContainer, FadeDiv, FadeSpan } from "../Fade"
 import { VideoBackground } from "./VideoBackground"
 
@@ -38,12 +39,12 @@ export function Hero() {
           <FadeSpan>for Tesla owners.</FadeSpan>
         </p>
         <FadeDiv>
-          <a
+          <Link
             className="font-colfax mt-6 inline-flex cursor-pointer flex-row items-center justify-center gap-1 rounded-md border-b-[1.5px] border-orange-700 bg-linear-to-b from-orange-400 to-orange-500 px-5 py-3 leading-4 font-medium tracking-wide whitespace-nowrap text-white shadow-[0_0_0_2px_rgba(0,0,0,0.04),0_0_14px_0_rgba(255,255,255,0.19)] transition-all duration-200 ease-in-out hover:shadow-orange-300"
-            href="#"
+            href="/products"
           >
             Shop Tint Kits
-          </a>
+          </Link>
         </FadeDiv>
         <div className="absolute inset-0 -z-10">
           <VideoBackground 


### PR DESCRIPTION
## Summary
- link "Shop Tint Kits" hero button to `/products` using Next.js `Link`

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b93bdb4748832aaab71d2d4f79a3b7