### PR TITLE
fix: align page content width

### DIFF
--- a/src/app/install-guides/page.tsx
+++ b/src/app/install-guides/page.tsx
@@ -73,7 +73,7 @@ export default function InstallGuidesPage() {
   return (
     <main className="relative">
       <FadeContainer className="relative px-6 pt-28 pb-16 lg:px-8">
-        <div className="mx-auto max-w-7xl">
+        <div className="mx-auto max-w-6xl">
           {/* Header */}
           <FadeDiv className="mb-16 text-center">
             <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -11,7 +11,7 @@ export default function ProductsPage() {
   return (
     <main className="relative">
       <FadeContainer className="relative px-6 pt-28 pb-16 lg:px-8">
-        <div className="mx-auto max-w-7xl">
+        <div className="mx-auto max-w-6xl">
           {/* Header */}
           <FadeDiv className="text-center mb-16">
             <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">

--- a/src/app/store/page.tsx
+++ b/src/app/store/page.tsx
@@ -11,7 +11,7 @@ export default function StorePage() {
   return (
     <main className="relative">
       <FadeContainer className="relative px-6 pt-28 pb-16 lg:px-8">
-        <div className="mx-auto max-w-7xl">
+        <div className="mx-auto max-w-6xl">
           {/* Header */}
           <FadeDiv className="text-center mb-16">
             <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">

--- a/src/app/support/billing/page.tsx
+++ b/src/app/support/billing/page.tsx
@@ -165,7 +165,7 @@ export default function BillingPage() {
     <main className="min-h-screen bg-gray-50">
       {/* Hero Section */}
       <section className="relative bg-gradient-to-b from-white to-gray-50 pt-24 pb-16">
-        <FadeContainer className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <FadeContainer className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <FadeDiv>
               <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-purple-100">

--- a/src/app/support/compatibility/page.tsx
+++ b/src/app/support/compatibility/page.tsx
@@ -177,7 +177,7 @@ export default function CompatibilityPage() {
     <main className="min-h-screen bg-gray-50">
       {/* Hero Section */}
       <section className="relative bg-gradient-to-b from-white to-gray-50 pt-24 pb-16">
-        <FadeContainer className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <FadeContainer className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <FadeDiv>
               <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-indigo-100">

--- a/src/app/support/legal/page.tsx
+++ b/src/app/support/legal/page.tsx
@@ -52,7 +52,7 @@ export default function LegalPage() {
     <main className="min-h-screen bg-gray-50">
       {/* Hero Section */}
       <section className="relative bg-gradient-to-b from-white to-gray-50 pt-24 pb-16">
-        <FadeContainer className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <FadeContainer className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <FadeDiv>
               <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-gray-100">
@@ -71,7 +71,7 @@ export default function LegalPage() {
 
       {/* Legal Categories */}
       <section className="py-16">
-        <FadeContainer className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <FadeContainer className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
             {legalCategories.map((category) => (
               <FadeDiv key={category.title}>

--- a/src/app/support/legal/privacy/page.tsx
+++ b/src/app/support/legal/privacy/page.tsx
@@ -25,7 +25,7 @@ export default function PrivacyPolicyPage() {
     <main className="min-h-screen bg-gray-50">
       {/* Hero Section */}
       <section className="relative bg-gradient-to-b from-white to-gray-50 pt-24 pb-16">
-        <FadeContainer className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <FadeContainer className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <FadeDiv>
               <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-green-100">

--- a/src/app/support/legal/terms/page.tsx
+++ b/src/app/support/legal/terms/page.tsx
@@ -28,7 +28,7 @@ export default function TermsOfServicePage() {
     <main className="min-h-screen bg-gray-50">
       {/* Hero Section */}
       <section className="relative bg-gradient-to-b from-white to-gray-50 pt-24 pb-16">
-        <FadeContainer className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <FadeContainer className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <FadeDiv>
               <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-orange-100">

--- a/src/app/support/legal/tinting-laws/page.tsx
+++ b/src/app/support/legal/tinting-laws/page.tsx
@@ -93,7 +93,7 @@ export default function TintingLawsPage() {
     <main className="min-h-screen bg-gray-50">
       {/* Hero Section */}
       <section className="relative bg-gradient-to-b from-white to-gray-50 pt-24 pb-16">
-        <FadeContainer className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <FadeContainer className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <FadeDiv>
               <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-blue-100">

--- a/src/app/support/oops/page.tsx
+++ b/src/app/support/oops/page.tsx
@@ -25,7 +25,7 @@ export default function OopsPage() {
     <main className="min-h-screen bg-gray-50">
       {/* Hero Section */}
       <section className="relative bg-gradient-to-b from-white to-gray-50 pt-24 pb-16">
-        <FadeContainer className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <FadeContainer className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <FadeDiv>
               <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-orange-100">

--- a/src/app/support/orders/page.tsx
+++ b/src/app/support/orders/page.tsx
@@ -91,7 +91,7 @@ export default function OrdersPage() {
     <main className="min-h-screen bg-gray-50">
       {/* Hero Section */}
       <section className="relative bg-gradient-to-b from-white to-gray-50 pt-24 pb-16">
-        <FadeContainer className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <FadeContainer className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <FadeDiv>
               <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-green-100">

--- a/src/components/products/ProductHero.tsx
+++ b/src/components/products/ProductHero.tsx
@@ -46,7 +46,7 @@ export function ProductHero({ product, selectedVariant, onVariantChange }: Produ
 
   return (
     <div className="px-6 pt-28 pb-16 lg:px-8">
-      <div className="mx-auto max-w-7xl">
+      <div className="mx-auto max-w-6xl">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start">
           {/* Product Images */}
           <FadeDiv>

--- a/src/components/store/CartPage.tsx
+++ b/src/components/store/CartPage.tsx
@@ -66,7 +66,7 @@ export function CartPage() {
   return (
     <main className="relative">
       <FadeContainer className="relative px-6 pt-28 pb-16 lg:px-8">
-        <div className="mx-auto max-w-7xl">
+        <div className="mx-auto max-w-6xl">
           <FadeDiv>
             <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl mb-8">
               Shopping Cart

--- a/src/components/support/ContactHero.tsx
+++ b/src/components/support/ContactHero.tsx
@@ -8,7 +8,7 @@ export function ContactHero() {
     <section className="relative bg-gradient-to-br from-green-50 via-white to-emerald-50 py-24 sm:py-32">
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(34,197,94,0.1),transparent_50%)]" />
       
-      <FadeContainer className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <FadeContainer className="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         <div className="text-center">
           <FadeDiv>
             <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100 mb-6">

--- a/src/components/support/FAQHero.tsx
+++ b/src/components/support/FAQHero.tsx
@@ -8,7 +8,7 @@ export function FAQHero() {
     <section className="relative bg-gradient-to-br from-blue-50 via-white to-indigo-50 py-24 sm:py-32">
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(59,130,246,0.1),transparent_50%)]" />
       
-      <FadeContainer className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <FadeContainer className="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         <div className="text-center">
           <FadeDiv>
             <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-blue-100 mb-6">

--- a/src/components/support/SupportCategoryGrid.tsx
+++ b/src/components/support/SupportCategoryGrid.tsx
@@ -79,7 +79,7 @@ const supportCategories = [
 export function SupportCategoryGrid() {
   return (
     <section id="tools-section" className="py-16">
-      <FadeContainer className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <FadeContainer className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         <FadeDiv>
           <div className="text-center">
             <h2 className="font-barlow text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">

--- a/src/components/support/SupportHero.tsx
+++ b/src/components/support/SupportHero.tsx
@@ -24,7 +24,7 @@ export function SupportHero() {
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(251,146,60,0.1),transparent_50%)]" />
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_70%_80%,rgba(251,146,60,0.05),transparent_50%)]" />
       
-      <FadeContainer className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <FadeContainer className="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         <div className="text-center">
           <FadeDiv>
             <h1 className="font-barlow text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">

--- a/src/components/support/WarrantyHero.tsx
+++ b/src/components/support/WarrantyHero.tsx
@@ -8,7 +8,7 @@ export function WarrantyHero() {
     <section className="relative bg-gradient-to-br from-orange-50 via-white to-red-50 py-24 sm:py-32">
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(249,115,22,0.1),transparent_50%)]" />
       
-      <FadeContainer className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <FadeContainer className="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         <div className="text-center">
           <FadeDiv>
             <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-orange-100 mb-6">


### PR DESCRIPTION
## Summary
- align page content width with header and footer by standardizing containers to max-w-6xl

## Testing
- `pnpm run lint`
- `pnpm run build` *(fails: Neither apiKey nor config.authenticator provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d2e20544832abb627fdffd97fc62