### PR TITLE
fix: add background to mobile menu

### DIFF
--- a/src/components/menu-bar.tsx
+++ b/src/components/menu-bar.tsx
@@ -255,7 +255,12 @@ export const MenuBar = React.memo(function MenuBar() {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -8 }}
               transition={fastTransition}
-              className="mt-4 flex flex-col gap-2 lg:hidden"
+              className={cx(
+                "mt-4 flex flex-col gap-2 lg:hidden rounded-xl p-4 border shadow-lg",
+                scrolled || isLightPage
+                  ? "bg-white/90 border-gray-200/50"
+                  : "bg-gray-900/90 border-gray-700/50",
+              )}
             >
               {menuItems.map((item) => (
                 <Link


### PR DESCRIPTION
## Summary
- improve mobile menu readability with a solid background, border, and shadow

## Testing
- `pnpm run lint`
- `pnpm run build` *(fails: Failed to collect page data for /api/order-details)*

------
https://chatgpt.com/codex/tasks/task_e_68ba818f5de4832aa865f92f1426757b